### PR TITLE
Firefox and chrome support: Replacing BigInt with Number.isSafeInteger

### DIFF
--- a/future-apps/payroll/app/src/store/marshalling.js
+++ b/future-apps/payroll/app/src/store/marshalling.js
@@ -3,11 +3,12 @@ export function currency (value) {
 }
 
 export function date (epoch) {
-  if (!epoch || BigInt(epoch) > Number.MAX_SAFE_INTEGER) { // eslint-disable-line
+  const epochInt = parseInt(epoch)
+  if (!epoch || !Number.isSafeInteger(epochInt)) {
     return null
   }
 
-  return parseInt(epoch) * 1000
+  return epochInt * 1000
 }
 
 export function employee (data) {


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase <josx@interorganic.com.ar>

Fixes #46